### PR TITLE
Fix for imported private key wallets (non HD)

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -258,7 +258,7 @@ class WalletConnectDialog(WindowModalDialog):
         if address_str:
             self.address = address.Address.from_string(address_str)
         else:
-            self.address = self.wallet.get_unused_address(frozen_ok=False)
+            self.address = self.wallet.get_unused_address(frozen_ok=False) or self.wallet.dummy_address()
             self.wallet.storage.put("wallet_connect_address", self.address.to_cashaddr())
             self.wallet.storage.write()
         self.wallet.set_frozen_state([self.address], True)


### PR DESCRIPTION
This fixes it so those wallets work with this plugin, otherwise the plugin fails with an exception:

![IMAGE 2026-03-06 13:39:37](https://github.com/user-attachments/assets/9166bfed-aa98-456e-81c6-ffd0052e79af)
